### PR TITLE
Text Map Propagator

### DIFF
--- a/pkg/opentelemetry/options.go
+++ b/pkg/opentelemetry/options.go
@@ -2,12 +2,14 @@ package opentelemetry
 
 import (
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
 )
 
 // config represents the configuration options available for subscriber
 // middlewares and publisher decorators.
 type config struct {
-	spanAttributes []attribute.KeyValue
+	spanAttributes    []attribute.KeyValue
+	textMapPropagator propagation.TextMapPropagator
 }
 
 // Option provides a convenience wrapper for simple options that can be
@@ -18,5 +20,15 @@ type Option func(*config)
 func WithSpanAttributes(attributes ...attribute.KeyValue) Option {
 	return func(c *config) {
 		c.spanAttributes = attributes
+	}
+}
+
+// WithTextMapPropagator sets the TextMapPropagator in order to propagate context data across process boundaries.
+func WithTextMapPropagator() Option {
+	return func(c *config) {
+		c.textMapPropagator = propagation.NewCompositeTextMapPropagator(
+			propagation.TraceContext{},
+			propagation.Baggage{},
+		)
 	}
 }

--- a/pkg/opentelemetry/subscribers_test.go
+++ b/pkg/opentelemetry/subscribers_test.go
@@ -1,10 +1,12 @@
 package opentelemetry
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/ThreeDotsLabs/watermill/message"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func TestTrace(t *testing.T) {
@@ -21,6 +23,47 @@ func TestTrace(t *testing.T) {
 	h := func(m *message.Message) ([]*message.Message, error) {
 		if got, want := m.UUID, uuid; got != want {
 			t.Fatalf("m.UUID = %q, want %q", got, want)
+		}
+
+		return nil, nil
+	}
+
+	if _, err := middleware(h)(msg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTraceWithTextMapPropagator(t *testing.T) {
+	middleware := Trace(WithTextMapPropagator())
+
+	var (
+		traceParentKey = "traceparent"
+		traceID, _     = trace.TraceIDFromHex("093615e8ce177910353c5a09782ba62a")
+		spanID, _      = trace.SpanIDFromHex("98c5fa0e132dd10d")
+		sc             = trace.NewSpanContext(trace.SpanContextConfig{
+			TraceID: traceID,
+			SpanID:  spanID,
+			Remote:  true,
+		})
+		traceParentID = fmt.Sprintf("00-%s-%s-00", traceID.String(), spanID.String())
+		uuid          = "52219531-0cd8-4b64-be31-ba6b4ef01472"
+		payload       = message.Payload("test payload for Trace")
+		msg           = message.NewMessage(uuid, payload)
+	)
+
+	msg.Metadata.Set(traceParentKey, traceParentID)
+
+	h := func(m *message.Message) ([]*message.Message, error) {
+		if got, want := m.UUID, uuid; got != want {
+			t.Fatalf("m.UUID = %q, want %q", got, want)
+		}
+
+		msgContext := m.Context()
+
+		if !sc.Equal(trace.SpanContextFromContext(msgContext)) {
+			scJSON, _ := sc.MarshalJSON()
+			extractedScJSON, _ := trace.SpanContextFromContext(msgContext).MarshalJSON()
+			t.Fatalf("span context = %v, want %v", string(extractedScJSON), string(scJSON))
 		}
 
 		return nil, nil


### PR DESCRIPTION
Add `WithTextMapPropagator` option to implement [Text Map Propagator](https://opentelemetry.io/docs/specs/otel/context/api-propagators/#textmap-propagator). You can run my example [here](https://github.com/farizap/watermill-opentelemetry/tree/text_map_propagator_example/_examples/propagator). Below is a screenshot in jaeger UI when WithTextMapPropagator implemented. The trace shares the same parent traceID when it runs in two different process/service

![image](https://github.com/user-attachments/assets/60dae7ce-7856-45de-86a7-cc81c867ac99)
